### PR TITLE
fix: avoid extra underline when third argument of \major is empty

### DIFF
--- a/swjtuthesis.cls
+++ b/swjtuthesis.cls
@@ -384,7 +384,7 @@
         \begin{minipage}{12cm} 
           \centering                
           \makebox[6em][r]{Discipline~} \swjtu@fillinblank{11em}{\swjtu@enmajorFirst} \par
-        \ifx\swjtu@enmajorSecond\@empty \else
+        \if\relax\detokenize\expandafter{\swjtu@enmajorSecond}\relax \else
           \makebox[6em][r]{} \swjtu@fillinblank{11em}{\swjtu@enmajorSecond} \par
         \fi
           \makebox[6em][r]{Student ID~} \swjtu@fillinblank{11em}{\swjtu@studentid} \par


### PR DESCRIPTION
## 问题现象
当使用 `\major{...}{...}{}` 时，如果专业名称比较短，只用占用一条横线，此时第三个参数只能保持为空（例如 `{}`），不然编译会失败，但加入`{}` 会错误触发后续渲染逻辑，导致多输出一条空白横线。
<img width="800" height="162" alt="a995b5e7ac2a9ce040abdcf76fd2416c" src="https://github.com/user-attachments/assets/5da8b75a-e77c-4ccc-9144-3d36084ad982" />

## 原实现问题
原代码使用：
\ifx\swjtu@enmajorSecond\@empty

来判断参数是否为空。但在实际使用中，当参数形式为 `{}` 时，该判断无法正确识别空内容，导致条件分支未按预期进入，从而执行了后续的渲染代码。该判空方式对空参数的兼容性不足。

## 修改方式

将原有的 `\ifx ... \@empty` 判空方式替换为：

\if\relax\detokenize\expandafter{\swjtu@enmajorSecond}\relax

通过 `\detokenize` 将参数内容标准化为可比较的字符序列，再结合 `\relax` 进行边界判断，从而实现对 `{}` 情况的可靠识别。

## 修改结果
现在当第三个参数为空时，可以正确渲染
<img width="1039" height="249" alt="image" src="https://github.com/user-attachments/assets/da57c9b8-855a-493f-9686-21860200eb7d" />
